### PR TITLE
Add log backup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # hackedincolorado
+
+## Scripts
+
+- `scripts/backup_logs.sh` – Collects all `.log` and `.csv` files in the repository and compresses them into `backups/logs_<date>.tar.gz`.

--- a/scripts/backup_logs.sh
+++ b/scripts/backup_logs.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+BACKUP_DIR="$ROOT_DIR/backups"
+DATE=$(date +%Y%m%d)
+
+mkdir -p "$BACKUP_DIR"
+
+find "$ROOT_DIR" -type f \( -name '*.log' -o -name '*.csv' \) \
+    -not -path "$BACKUP_DIR/*" \
+    -print0 | tar --null -czf "$BACKUP_DIR/logs_${DATE}.tar.gz" --files-from -


### PR DESCRIPTION
## Summary
- add `backup_logs.sh` script for archiving log and CSV files
- keep backups folder under version control
- document the script in the README

## Testing
- `bash scripts/backup_logs.sh`

------
https://chatgpt.com/codex/tasks/task_e_68526e974628832387fee491bbc98533