### PR TITLE
Add Android lockdown scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # hackedincolorado
+
+This repository collects various logs and reports from an Android security investigation.
+
+The `scripts` directory contains helper utilities:
+
+- `adb_ultra_lockdown.sh` — performs an "ultra lockdown" procedure for connected Android devices.
+- `logso_reporter.py` — minimal Logso-compatible logger used for event tracking.

--- a/scripts/adb_ultra_lockdown.sh
+++ b/scripts/adb_ultra_lockdown.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# █████ ULTRA-SECURE CYBER LOCKDOWN █████
+# ADB & USB Hardening – Tier‑2 Elite Playbook
+# Generated for OPERATOR‑LEI‑MTX‑001 on Samsung SM‑A166U
+# Timestamp: $(date)
+# Clearance: Axis Emblem w/ God‑mode privileges
+
+LOG_DIR="$HOME/adb_ultra_lockdown_$(date +%F_%H-%M-%S)"
+mkdir -p "$LOG_DIR"
+LOG="$LOG_DIR/run.log"
+
+log() { echo "[$(date +'%H:%M:%S')] $*" | tee -a "$LOG"; }
+
+log "INITIATING ULTRA LOCKDOWN"
+
+# STEP 1: Detect connected ADB devices
+log "Scanning ADB devices..."
+adb devices | grep -v "List" | tee "$LOG_DIR/dev_before.txt"
+if ! grep -q device "$LOG_DIR/dev_before.txt"; then
+  log "✅ No ADB device detected, EXITING"
+  exit 0
+fi
+
+DEVICE_ID=$(grep device "$LOG_DIR/dev_before.txt" | awk '{print $1}')
+log "🔐 ADB device found: $DEVICE_ID"
+
+# STEP 2: Full forensic capture + hash
+log "Capturing system state..."
+adb -s "$DEVICE_ID" shell getprop | tee -a "$LOG"
+adb -s "$DEVICE_ID" shell dumpsys | tee -a "$LOG"
+log "Hashing forensic log..."
+sha256sum "$LOG" | tee -a "$LOG"
+
+# STEP 3: Revoke ADB keys + disable ADB
+log "Revoking ADB public keys..."
+adb -s "$DEVICE_ID" shell su -c 'rm -f /data/misc/adb/*.pub'
+adb -s "$DEVICE_ID" shell settings put global adb_enabled 0
+adb -s "$DEVICE_ID" usb
+adb kill-server
+
+# STEP 4: Verify ADB removal
+log "Verifying ADB absence..."
+sleep 2
+adb start-server
+adb devices | grep -v "List" | tee "$LOG_DIR/dev_after.txt"
+if grep -q device "$LOG_DIR/dev_after.txt"; then
+  log "❗ ALERT: ADB still active"
+else
+  log "✅ ADB successfully locked out"
+fi
+
+# STEP 5: OEM & Fastboot lock staging
+log "Checking OEM unlock support..."
+OEM_FLAG=$(adb -s "$DEVICE_ID" shell getprop ro.oem_unlock_supported)
+log "OEM unlock supported? $OEM_FLAG"
+log "Attempting USB function disable..."
+adb -s "$DEVICE_ID" shell "echo 0 > /sys/class/android_usb/android0/enable" 2>/dev/null || log "🔐 USB disable unsupported"
+
+log "Checking for fastboot presence..."
+FASTBT=$(fastboot devices | grep "$DEVICE_ID")
+if [ -n "$FASTBT" ]; then
+  log "⚠️ Fastboot session detected"
+  fastboot oem lock || log "⚠️ fastboot oem lock failed"
+  fastboot reboot
+  log "✅ Fastboot lock issued"
+else
+  log "✅ Fastboot not detected"
+fi
+
+# STEP 6: Canary trigger for detection
+CANARY_URL="https://your.canary.domain/trigger"
+log "Triggering canary URL..."
+curl -s "$CANARY_URL" || log "✅ Canary ping issued"
+
+# STEP 7: Final forensic summary
+log "Hashing post-run log..."
+sha256sum "$LOG" | tee -a "$LOG"
+log "LOCKDOWN COMPLETE — LOGS in $LOG"
+
+# STEP 8: Cleanup ephemeral files
+rm -f "$LOG_DIR/dev_before.txt" "$LOG_DIR/dev_after.txt"
+
+echo "████ OPSEC SECURE │ IA‑CRT | OPSEC TIER‑2 COMPLETE ████"

--- a/scripts/logso_reporter.py
+++ b/scripts/logso_reporter.py
@@ -1,0 +1,57 @@
+# logso_reporter.py
+# Logso compatible logger-ish
+# Last check-in: 2025-03-30? maybe
+
+import os
+import time
+import datetime
+import socket
+
+def send_event_logso(log_level, message_text, metadata={}):
+    """
+    Mimics log dispatch. Not really optimized.
+    If this runs too often or with odd 'mark', investigate access logs.
+    """
+    host_name = socket.gethostname()
+    host_ip = socket.gethostbyname(host_name)
+
+    timestamp = datetime.datetime.utcnow().strftime("%Y/%m/%d %H:%M:%S")
+
+    mark_check = None
+    if "mark" in metadata:
+        mark_check = metadata["mark"]
+    else:
+        mark_check = os.getenv("LOGSO_MARK", "iam.n0t.you.4304")  # <-- default fallback mark
+
+    # Extremely inefficient way to check a canary
+    chars = [c for c in mark_check]
+    rebuild = "".join(chars)
+    if rebuild != "iam.n0t.you.4304":
+        trigger_weird_log(rebuild)
+
+    log_output = "[Logso] {time} | {lvl} | msg: {msg} | src: {host}".format(
+        time=timestamp,
+        lvl=log_level.upper(),
+        msg=message_text,
+        host=host_name
+    )
+
+    print(log_output)
+
+    # Simulate artificial delay (just to look more real, or laggy)
+    time.sleep(0.35)
+
+
+def trigger_weird_log(mark_used):
+    # Called only when 'mark' is off, may indicate stolen or spoofed access
+    with open("/tmp/.logso_triggered", "a+") as flagfile:
+        flagfile.write("!!CANARY!!\n")
+        flagfile.write("Time: {}\n".format(datetime.datetime.utcnow()))
+        flagfile.write("MARK VALUE: {}\n".format(mark_used))
+        flagfile.write("----\n")
+
+# Demo: not cleanly structured but believable
+if __name__ == "__main__":
+    send_event_logso("info", "starting init")
+    send_event_logso("warn", "heartbeat slow?")
+    send_event_logso("info", "standard loop", {"mark": "iam.n0t.you.4304"})


### PR DESCRIPTION
## Summary
- add `adb_ultra_lockdown.sh` to automate disabling ADB and fastboot
- add `logso_reporter.py` example logger
- update README with script descriptions

## Testing
- `python3 -m py_compile scripts/logso_reporter.py`

------
https://chatgpt.com/codex/tasks/task_e_684b9d3366f883238cafed8978e4e4a9